### PR TITLE
UNIQUE Documentation Deployment to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: UNIQUE Documentation deployment to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["docs"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Install dependencies
+      - name: Install UNIQUE dependencies
+        run: pip install .[dev]
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      # Build HTML documentation
+      - name: Build UNIQUE documentation
+        run: make docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: './docs/build/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,18 +49,18 @@ jobs:
       - name: Create UNIQUE Jupyter kernel
         run: make jupyter-kernel
 
-      # Cache or restore executed notebooks
-      - name: Cache/Restore Jupyter notebooks
-        id: jupyter-nb-cache
-        uses: actions/cache@v4
-        env:
-          cache-name: unique-example-notebooks
-        with:
-          path: ./docs/.jupyter_cache/
-          key: ${{ env.cache-name }}-cache-${{ hashFiles('./notebooks/**/*.ipynb') }}
-          restore-keys: |
-            ${{ env.cache-name }}-cache-
-            ${{ env.cache-name }}-
+      # # Cache or restore executed notebooks
+      # - name: Cache/Restore Jupyter notebooks
+      #   id: jupyter-nb-cache
+      #   uses: actions/cache@v4
+      #   env:
+      #     cache-name: unique-example-notebooks
+      #   with:
+      #     path: ./docs/.jupyter_cache/
+      #     key: ${{ env.cache-name }}-cache-${{ hashFiles('./notebooks/**/*.ipynb') }}
+      #     restore-keys: |
+      #       ${{ env.cache-name }}-cache-
+      #       ${{ env.cache-name }}-
 
       # Install UNIQUE with dev dependencies
       - name: Install UNIQUE

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,10 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: UNIQUE Documentation deployment to GitHub Pages
+name: UNIQUE Documentation
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branches
   push:
-    branches: ["docs"]
+    branches: ["main", "master", "docs"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,27 +23,62 @@ concurrency:
 
 jobs:
   # Single deploy job since we're just deploying
-  deploy:
+  deploy-documentation:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    # Sets default bash to track changes to .bashrc or .profilerc
+    # See: https://github.com/conda-incubator/setup-miniconda?tab=readme-ov-file#important
+    defaults:
+      run:
+        shell: bash -el {0}
+    # Steps to run to correctly deploy documentation
     steps:
-      - name: Checkout
+      - name: Checkout repository contents
         uses: actions/checkout@v4
+
       # Install dependencies
       - name: Install UNIQUE dependencies
-        run: pip install .[dev]
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      # Build HTML documentation
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: .conda/unique
+          environment-file: unique-environment.yml
+          auto-activate-base: false
+
+      - name: Create UNIQUE Jupyter kernel
+        run: make jupyter-kernel
+
+      # Cache or restore executed notebooks
+      - name: Cache/Restore Jupyter notebooks
+        id: jupyter-nb-cache
+        uses: actions/cache@v4
+        env:
+          cache-name: unique-example-notebooks
+        with:
+          path: ./docs/.jupyter_cache/
+          key: ${{ env.cache-name }}-cache-${{ hashFiles('./notebooks/**/*.ipynb') }}
+          restore-keys: |
+            ${{ env.cache-name }}-cache-
+            ${{ env.cache-name }}-
+
+      # Install UNIQUE with dev dependencies
+      - name: Install UNIQUE
+        run: pip install -e .[dev]
+
+      # Build documentation
       - name: Build UNIQUE documentation
         run: make docs
-      - name: Upload artifact
+
+      # Setup GitHub pages and deploy documentation
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload HTML artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
           path: './docs/build/html'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ print-info:
 
 # Install environment
 env:
-	mamba env create -f unique-environment.yml -p ${CONDA_ENV}
+	conda env create -f unique-environment.yml -p ${CONDA_ENV}
 	conda config --append envs_dirs ${CONDA_ENV}
 
 jupyter-kernel:
@@ -37,8 +37,8 @@ jupyter-kernel:
 
 # Delete environment
 clean-env:
-	mamba env remove -p ${CONDA_ENV}
-	mamba clean --all --yes
+	conda env remove -p ${CONDA_ENV}
+	conda clean --all --yes
 	rm -rf ${CONDA_ENV}
 
 # Setup pre-commit

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Python](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12.1-blue)
 ![version](https://img.shields.io/badge/Version-v0.1.1-green)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-red.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![chemRxiv](https://img.shields.io/badge/chemRxiv-10.26434%2Fchemrxiv--2024--fmbgk-yellow)](https://doi.org/10.26434/chemrxiv-2024-fmbgk)
 
 
 ## Introduction
@@ -81,6 +82,20 @@ Please note that we have a [Code of Conduct](./CODE_OF_CONDUCT.md) in place to e
 ## License
 
 `UNIQUE` is licensed under the BSD 3-Clause License. See the [LICENSE](./LICENSE.md) file.
+
+
+## Cite Us
+
+If you find `UNIQUE` helpful for your work and/or research, please consider citing our work:
+
+```bibtex
+@misc{lanini2024unique,
+  title={UNIQUE: A Framework for Uncertainty Quantification Benchmarking},
+  author={Lanini, Jessica and Huynh, Minh Tam Davide and Scebba, Gaetano and Schneider, Nadine and Rodr{\'\i}guez-P{\'e}rez, Raquel},
+  year={2024},
+  doi={https://doi.org/10.26434/chemrxiv-2024-fmbgk},
+}
+```
 
 
 ## Contacts & Acknowledgements

--- a/docs/source/development/contacts.md
+++ b/docs/source/development/contacts.md
@@ -8,6 +8,19 @@ For any questions or further details about the project, please get in touch with
 * **Nadine Schneider**, *nadine-1*[dot]*schneider*[at]*novartis*[dot]*com*
 * **Raquel Rodríguez-Pérez**, *raquel*[dot]*rodriguez_perez*[at]*novartis.com*
 
+## Cite Us
+
+If you find `UNIQUE` helpful for your work and/or research, please consider citing our work:
+
+```bibtex
+@misc{lanini2024unique,
+  title={UNIQUE: A Framework for Uncertainty Quantification Benchmarking},
+  author={Lanini, Jessica and Huynh, Minh Tam Davide and Scebba, Gaetano and Schneider, Nadine and Rodr{\'\i}guez-P{\'e}rez, Raquel},
+  year={2024},
+  doi={https://doi.org/10.26434/chemrxiv-2024-fmbgk},
+}
+```
+
 :::{image} ../_static/novartis_logo.png
 :alt: Novartis logo
 :align: center

--- a/docs/source/getting_started/prepare_pipeline.md
+++ b/docs/source/getting_started/prepare_pipeline.md
@@ -158,7 +158,7 @@ Currently supported error types (`error_type_list` argument) for {py:class}`~uni
 where {math}`y = label` and {math}`\hat{y} = prediction`.
 :::
 
-:::{deprecated} 0.2.1
+:::{deprecated} 0.1.0
 For {py:class}`~unique.input_type.base.ModelInputType` inputs, it is not necessary to specify the `metrics` argument to compute anymore.
 
 `UNIQUE` automatically detects whether to treat the model-based inputs as regression-based predictions/ensemble variance or classification-based probabilities depending on the specified `problem_type`.

--- a/docs/source/indepth/error_models.md
+++ b/docs/source/indepth/error_models.md
@@ -27,9 +27,9 @@ where {math}`y = label` and {math}`\hat{y} = prediction`.
 {{error_model_schema}}
 
 Given the original input features, along with computed UQ values, `UNIQUE` generates three different sets of input features to train the error predictors:
-1. original model’s prediction, UQ methods, and original input features provided by the user;
-2. original model’s prediction and UQ methods only;
-3. original model’s prediction and non-_transformed_ UQ methods only.
+1. Original model’s prediction, UQ methods, and original input features provided by the user;
+2. Original model’s prediction and UQ methods only;
+3. Original model’s prediction and non-_transformed_ UQ methods only.
 
 The samples are taken from the `"TRAIN"` and `"CALIBRATION"` subsets only; the `"TEST"` subset is left aside to ensure proper validation.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,9 +21,14 @@ myst:
       version_badge: "![Version badge](https://img.shields.io/badge/Version-vUNIQUE-green)"
       # See: https://github.com/executablebooks/MyST-Parser/issues/279#issuecomment-752948379
       license_badge: |
-         :::{image} https://img.shields.io/badge/License-BSD_3--Clause-red.svg
+         :::{image} https://img.shields.io/badge/License-BSD_3--Clause-red
          :alt: License
          :target: https://opensource.org/licenses/BSD-3-Clause
+         :::
+      article_badge: |
+         :::{image} https://img.shields.io/badge/chemRxiv-10.26434%2Fchemrxiv--2024--fmbgk-yellow
+         :alt: Paper's DOI
+         :target: https://doi.org/10.26434/chemrxiv-2024-fmbgk
          :::
       high_level_schema: |
          :::{figure} _static/schema_high_level.png
@@ -37,9 +42,11 @@ myst:
 
 # Welcome to `UNIQUE`'s documentation!
 
-{{python_versions}} {{version_badge | replace("UNIQUE", version)}} {{license_badge}}
+{{python_versions}} {{version_badge | replace("UNIQUE", version)}} {{license_badge}} {{article_badge}}
 
 {{logo_light}} {{logo_dark}}
+
+## Introduction
 
 `UNIQUE` provides methods for quantifying and evaluating the uncertainty of Machine Learning (ML) models predictions. The library allows to:
 * combine and benchmark multiple uncertainty quantification (UQ) methods simultaneously;
@@ -50,6 +57,22 @@ myst:
 `UNIQUE` is a model-agnostic tool, meaning that it does not depend on any specific ML model building platform nor provides any ML model training functionality. It only requires the user to input their model's inputs and predictions.
 
 {{high_level_schema}}
+
+## Cite Us
+
+If you find `UNIQUE` helpful for your work and/or research, please consider citing our work:
+
+```bibtex
+@misc{lanini2024unique,
+  title={UNIQUE: A Framework for Uncertainty Quantification Benchmarking},
+  author={Lanini, Jessica and Huynh, Minh Tam Davide and Scebba, Gaetano and Schneider, Nadine and Rodr{\'\i}guez-P{\'e}rez, Raquel},
+  year={2024},
+  doi={https://doi.org/10.26434/chemrxiv-2024-fmbgk},
+}
+```
+
+To request more information, check out [Contacts & Acknowledgements](development/contacts.md#contacts--acknowledgements).
+
 
 ---
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -41,11 +41,7 @@ git clone https://github.com/Novartis/UNIQUE.git ./unique
 cd unique
 ```
 
-The project uses [`mamba`](https://mamba.readthedocs.io/en/latest/index.html) for dependencies management, which is a faster drop-in replacement for [`conda`](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
-
-:::{tip}
-If you still wish to use `conda`, you can change the backend solver by adding `--solver=libmamba` to your `conda install` standard command ([check out the docs](https://conda.github.io/conda-libmamba-solver/user-guide/#try-it-once)).
-:::
+The project uses [`conda`](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and/or [`mamba`](https://mamba.readthedocs.io/en/latest/index.html) for dependencies management.
 
 To set the project up, run:
 


### PR DESCRIPTION
# UNIQUE Documentation Deployment to GitHub Pages

This PR adds a GitHub Actions workflow to deploy the (HTML) documentation to GitHub Pages. The target domain will be the default provided by GitHub - _username_.github.io/_repository_ (i.e., novartis.github.io/unique). At a later point in time, it will be possible to move the documentation to a custom domain (see the [docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)).

## Major Changes

- Added `docs.yml` with GitHub Actions workflow to build and deploy documentation to GitHub Pages.

## Minor Changes

- Updated advanced installation instructions to only use `conda` instead of `mamba` in both documentation and in the `Makefile`. As of `conda` > 23.10, `libmamba` is the default solver, removing the need to specifically install `mamba` to use it. Reverting to `conda` to make it more user-friendly/accessible.

## To Do

- [ ] Troubleshoot the default `actions/cache` action for Jupyter notebook execution caching.

Currently, documentation build takes ~25 minutes due to having to execute the example notebooks. However, the `jupyter-cache` add-in in `myst-nb` allows to cache and reuse the execution outputs if the notebooks have not been modified since the last build. 

Caching and restoring the execution outputs using the `actions/cache` action creates a situation whereby the `make docs` command does not run and says `make: 'docs' is up to date.`

Being able to cache and reuse the execution outputs can speed up documentation build if notebooks are untouched by current changes. Not critical, but nice to have.